### PR TITLE
Fix type hinting issue with setStore()

### DIFF
--- a/src/Siftware/LiveConnect.php
+++ b/src/Siftware/LiveConnect.php
@@ -85,7 +85,7 @@ class LiveConnect
     * It may be more useful at bootstrapping stage, on subsequent requests
     * $this->getAccessToken() method (that you'll need pass into the request) will also
     * check token expiry & refresh if needed
-\    */
+    */
     public function authenticate($code = "")
     {
         $storedTokens = $this->tokenStore->getTokens();

--- a/src/Siftware/LiveConnect.php
+++ b/src/Siftware/LiveConnect.php
@@ -72,7 +72,7 @@ class LiveConnect
     *
     * @param TokenStore $store
     */
-    public function setStore(TokenStore $store)
+    public function setStore(\Siftware\TokenStore\TokenStore $store)
     {
         $this->tokenStore = $store;
     }


### PR DESCRIPTION
This fixes an error I encountered when trying to implement a custom token store outside of the Siftware namespace. It appears that PHP gets fussy if you don't specify the full namespace to the interface.
